### PR TITLE
Replace `centos8` with `rockylinux8`

### DIFF
--- a/.github/workflows/build-and-publish-images.yml
+++ b/.github/workflows/build-and-publish-images.yml
@@ -27,7 +27,7 @@ jobs:
           - "ubuntu18.04"
           - "ubuntu20.04"
           - "centos7"
-          - "centos8"
+          - "rockylinux8"
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
This PR replaces `centos8` with `rockylinux8` since RAPIDS no longer supports `centos8`.