### PR TITLE
Update Python related `ARG` and `ENV` values

### DIFF
--- a/.github/workflows/build-and-publish-images.yml
+++ b/.github/workflows/build-and-publish-images.yml
@@ -20,7 +20,7 @@ jobs:
           - "11.4.1"
           - "11.2.2"
           - "11.0.3"
-        PY_VER:
+        PYTHON_VER:
           - "3.8"
           - "3.9"
         LINUX_VER:
@@ -52,5 +52,5 @@ jobs:
           build-args: |
             CUDA_VER=${{ matrix.CUDA_VER }}
             LINUX_VER=${{ matrix.LINUX_VER }}
-            PY_VER=${{ matrix.PY_VER }}
-          tags: rapidsai/mambaforge-cuda:${{ matrix.CUDA_VER }}-base-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
+            PYTHON_VER=${{ matrix.PYTHON_VER }}
+          tags: rapidsai/mambaforge-cuda:${{ matrix.CUDA_VER }}-base-${{ matrix.LINUX_VER }}-py${{ matrix.PYTHON_VER }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM nvidia/cuda:${CUDA_VER}-base-${LINUX_VER}
 
 ARG PYTHON_VER=3.9
 ENV PATH=/opt/conda/bin:$PATH
+ENV PYTHON_VERSION=${PYTHON_VER}
 
 COPY --from=condaforge/mambaforge:4.13.0-1 /opt/conda /opt/conda
 RUN \
@@ -12,7 +13,7 @@ RUN \
   echo ". /opt/conda/etc/profile.d/conda.sh; conda activate base" >> /etc/skel/.bashrc; \
   echo ". /opt/conda/etc/profile.d/conda.sh; conda activate base" >> ~/.bashrc; \
   # install expected Python version
-  mamba install -y python="${PYTHON_VER}"; \
+  mamba install -y python="${PYTHON_VERSION}"; \
   mamba update --all -y; \
   find /opt/conda -follow -type f -name '*.a' -delete; \
   find /opt/conda -follow -type f -name '*.pyc' -delete; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG CUDA_VER=11.4.0
 ARG LINUX_VER=ubuntu18.04
 FROM nvidia/cuda:${CUDA_VER}-base-${LINUX_VER}
 
-ARG PY_VER=3.9
+ARG PYTHON_VER=3.9
 ENV PATH=/opt/conda/bin:$PATH
 
 COPY --from=condaforge/mambaforge:4.13.0-1 /opt/conda /opt/conda
@@ -12,7 +12,7 @@ RUN \
   echo ". /opt/conda/etc/profile.d/conda.sh; conda activate base" >> /etc/skel/.bashrc; \
   echo ". /opt/conda/etc/profile.d/conda.sh; conda activate base" >> ~/.bashrc; \
   # install expected Python version
-  mamba install -y python="${PY_VER}"; \
+  mamba install -y python="${PYTHON_VER}"; \
   mamba update --all -y; \
   find /opt/conda -follow -type f -name '*.a' -delete; \
   find /opt/conda -follow -type f -name '*.pyc' -delete; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG PYTHON_VER=3.9
 ENV PATH=/opt/conda/bin:$PATH
 ENV PYTHON_VERSION=${PYTHON_VER}
 
-COPY --from=condaforge/mambaforge:4.13.0-1 /opt/conda /opt/conda
+COPY --from=condaforge/mambaforge:4.14.0-0 /opt/conda /opt/conda
 RUN \
   # ensure conda environment is always activated
   ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh; \


### PR DESCRIPTION
This PR contains the following changes:

- Renames the `PY_VER` build argument to `PYTHON_VER`
- Adds a `PYTHON_VERSION` `ENV` value to the image, so that the Python version can be easily determined at runtime
- Updates the `mambaforge` image to `condaforge/mambaforge:4.14.0-0`