### PR TITLE
Add `latest` tag

### DIFF
--- a/.github/workflows/build-and-publish-images.yml
+++ b/.github/workflows/build-and-publish-images.yml
@@ -7,27 +7,45 @@ on:
         required: true
         type: boolean
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
+  compute-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      LATEST_UBUNTU_VER: ${{ steps.latest-values.outputs.LATEST_UBUNTU_VER }}
+      LATEST_CUDA_VER: ${{ steps.latest-values.outputs.LATEST_CUDA_VER }}
+      LATEST_PYTHON_VER: ${{ steps.latest-values.outputs.LATEST_PYTHON_VER }}
+      MATRIX: ${{ steps.compute-matrix.outputs.MATRIX }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Compute latest values
+        id: latest-values
+        run: |
+          set -x
+          LATEST_UBUNTU_VER=$(yq '.LINUX_VER | map(select(. == "*ubuntu*")) | sort | .[-1]' axis.yaml)
+          LATEST_CUDA_VER=$(yq '.CUDA_VER | sort | .[-1]' axis.yaml)
+          LATEST_PYTHON_VER=$(yq '.PYTHON_VER | sort | .[-1]' axis.yaml)
+
+          echo "::set-output name=LATEST_UBUNTU_VER::${LATEST_UBUNTU_VER}"
+          echo "::set-output name=LATEST_CUDA_VER::${LATEST_CUDA_VER}"
+          echo "::set-output name=LATEST_PYTHON_VER::${LATEST_PYTHON_VER}"
+      - name: Compute matrix
+        id: compute-matrix
+        run: |
+          MATRIX=$(yq -o json '.' axis.yaml | jq -c)
+          echo "::set-output name=MATRIX::${MATRIX}"
   docker:
+    needs: compute-matrix
     runs-on: ubuntu-latest
     env:
       DOCKERHUB_USERNAME: ${{ secrets.GPUCIBOT_DOCKERHUB_USER }}
       DOCKERHUB_TOKEN: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}
     strategy:
-      matrix:
-        CUDA_VER:
-          - "11.5.1"
-          - "11.4.1"
-          - "11.2.2"
-          - "11.0.3"
-        PYTHON_VER:
-          - "3.8"
-          - "3.9"
-        LINUX_VER:
-          - "ubuntu18.04"
-          - "ubuntu20.04"
-          - "centos7"
-          - "rockylinux8"
+      matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -41,16 +59,43 @@ jobs:
         with:
           username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ env.DOCKERHUB_TOKEN }}
+      - name: Compute Tags
+        id: compute-tags
+        run: |
+          set -x
+          TAGS="rapidsai/mambaforge-cuda:cuda${{ matrix.CUDA_VER }}-base-${{ matrix.LINUX_VER }}-py${{ matrix.PYTHON_VER }}"
+
+          if [[
+            "${{ needs.compute-matrix.outputs.LATEST_UBUNTU_VER }}" == "${{ matrix.LINUX_VER }}" &&
+            "${{ needs.compute-matrix.outputs.LATEST_CUDA_VER }}" == "${{ matrix.CUDA_VER }}" &&
+            "${{ needs.compute-matrix.outputs.LATEST_PYTHON_VER }}" == "${{ matrix.PYTHON_VER }}"
+          ]]; then
+            TAGS+=",latest"
+          fi
+          echo "::set-output name=TAGS::${TAGS}"
+      - name: Compute Platforms
+        id: compute-platforms
+        run: |
+          set -x
+          PLATFORMS="linux/amd64"
+
+          if [[
+            "${{ matrix.CUDA_VER }}" > "11.2.2" &&
+            "${{ matrix.LINUX_VER }}" != "centos7"
+          ]]; then
+            PLATFORMS+=",linux/arm64"
+          fi
+          echo "::set-output name=PLATFORMS::${PLATFORMS}"
       - name: Build and push
         timeout-minutes: 10
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: ${{ matrix.CUDA_VER >= '11.2.2' && matrix.LINUX_VER != 'centos7' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          platforms: ${{ steps.compute-platforms.outputs.PLATFORMS }}
           push: ${{ inputs.push }}
           pull: true
           build-args: |
             CUDA_VER=${{ matrix.CUDA_VER }}
             LINUX_VER=${{ matrix.LINUX_VER }}
             PYTHON_VER=${{ matrix.PYTHON_VER }}
-          tags: rapidsai/mambaforge-cuda:cuda${{ matrix.CUDA_VER }}-base-${{ matrix.LINUX_VER }}-py${{ matrix.PYTHON_VER }}
+          tags: ${{ steps.compute-tags.outputs.TAGS }}

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 A simple set of images that install [Mambaforge](https://github.com/conda-forge/miniforge) on top of the [nvidia/cuda](https://hub.docker.com/r/nvidia/cuda) images.
 
 These images are intended to be used as a base image for other RAPIDS images.
+
+## `latest` tag
+
+The `latest` tag is an alias for the Docker image that has the latest CUDA version, Python version, and Ubuntu version supported by this repository at any given time.

--- a/axis.yaml
+++ b/axis.yaml
@@ -1,0 +1,13 @@
+CUDA_VER:
+  - "11.5.1"
+  - "11.4.1"
+  - "11.2.2"
+  - "11.0.3"
+PYTHON_VER:
+  - "3.8"
+  - "3.9"
+LINUX_VER:
+  - "ubuntu18.04"
+  - "ubuntu20.04"
+  - "centos7"
+  - "rockylinux8"


### PR DESCRIPTION
This PR adds some changes to publish a `latest` tag for our images. The `latest` tag is an alias for the Docker image that has the latest CUDA version, Python version, and Ubuntu version supported by RAPIDS at any given time.

The `latest` tag is computed by examining a new `axis.yaml` file and determining latest the CUDA, Python, and Ubuntu versions. These versions are then used to dynamically compute the tags in the matrix build job.

The matrix build job itself is also now computed from the `axis.yaml` file.