### PR TITLE
Add `tzdata` package to `ubuntu` images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM nvidia/cuda:${CUDA_VER}-base-${LINUX_VER}
 
 ARG LINUX_VER
 ARG PYTHON_VER=3.9
+ARG DEBIAN_FRONTEND=noninteractive
 ENV PATH=/opt/conda/bin:$PATH
 ENV PYTHON_VERSION=${PYTHON_VER}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,12 @@ ARG CUDA_VER=11.4.0
 ARG LINUX_VER=ubuntu18.04
 FROM nvidia/cuda:${CUDA_VER}-base-${LINUX_VER}
 
+ARG LINUX_VER
 ARG PYTHON_VER=3.9
 ENV PATH=/opt/conda/bin:$PATH
 ENV PYTHON_VERSION=${PYTHON_VER}
 
-COPY --from=condaforge/mambaforge:22.9.0-0 /opt/conda /opt/conda
+COPY --from=condaforge/mambaforge:22.9.0-1 /opt/conda /opt/conda
 RUN \
   # ensure conda environment is always activated
   ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh; \
@@ -17,4 +18,20 @@ RUN \
   mamba update --all -y; \
   find /opt/conda -follow -type f -name '*.a' -delete; \
   find /opt/conda -follow -type f -name '*.pyc' -delete; \
-  conda clean -afy
+  conda clean -afy; \
+  case "${LINUX_VER}" in \
+    "ubuntu"*) \
+      apt-get update \
+      && apt-get upgrade -y \
+      && apt-get install -y --no-install-recommends \
+        tzdata \
+      && rm -rf "/var/lib/apt/lists/*"; \
+      ;; \
+    "centos"* | "rockylinux"*) \
+      yum -y update \
+      && yum clean all; \
+      ;; \
+    *) \
+      echo "Unsupported LINUX_VER: ${LINUX_VER}" && exit 1; \
+      ;; \
+  esac


### PR DESCRIPTION
This PR adds the `tzdata` package to our `ubuntu` images. `tzdata` is installed by default in the `centos` and `rockylinux` images. The `tzdata` package is necessary for some `arrow` operations, therefore it needs to be installed in our `ubuntu` images as well.

This PR also updates our `condaforge/mambaforge` image to `22.9.0-1`.