### PR TITLE
Split `mambaforge-cuda` image into two separate images

### DIFF
--- a/.github/workflows/build-and-publish-images.yml
+++ b/.github/workflows/build-and-publish-images.yml
@@ -63,16 +63,24 @@ jobs:
         id: compute-tags
         run: |
           set -x
-          TAGS="rapidsai/mambaforge-cuda:cuda${{ matrix.CUDA_VER }}-base-${{ matrix.LINUX_VER }}-py${{ matrix.PYTHON_VER }}"
+          BASE_NAME="rapidsai/mambaforge-cuda"
+          RAPIDS_NAME="${BASE_NAME}-rapids"
+
+          CURRENT_TAG="cuda${{ matrix.CUDA_VER }}-base-${{ matrix.LINUX_VER }}-py${{ matrix.PYTHON_VER }}"
+
+          BASE_TAGS="${BASE_NAME}:${CURRENT_TAG}"
+          RAPIDS_TAGS="${RAPIDS_NAME}:${CURRENT_TAG}"
 
           if [[
             "${{ needs.compute-matrix.outputs.LATEST_UBUNTU_VER }}" == "${{ matrix.LINUX_VER }}" &&
             "${{ needs.compute-matrix.outputs.LATEST_CUDA_VER }}" == "${{ matrix.CUDA_VER }}" &&
             "${{ needs.compute-matrix.outputs.LATEST_PYTHON_VER }}" == "${{ matrix.PYTHON_VER }}"
           ]]; then
-            TAGS+=",rapidsai/mambaforge-cuda:latest"
+            BASE_TAGS+=",${BASE_NAME}:latest"
+            RAPIDS_TAGS+=",${RAPIDS_NAME}:latest"
           fi
-          echo "TAGS=${TAGS}" >> ${GITHUB_OUTPUT}
+          echo "BASE_TAGS=${BASE_TAGS}" >> ${GITHUB_OUTPUT}
+          echo "RAPIDS_TAGS=${RAPIDS_TAGS}" >> ${GITHUB_OUTPUT}
       - name: Compute Platforms
         id: compute-platforms
         run: |
@@ -86,7 +94,7 @@ jobs:
             PLATFORMS+=",linux/arm64"
           fi
           echo "PLATFORMS=${PLATFORMS}" >> ${GITHUB_OUTPUT}
-      - name: Build and push
+      - name: Build and push mambaforge-cuda
         timeout-minutes: 10
         uses: docker/build-push-action@v3
         with:
@@ -94,8 +102,23 @@ jobs:
           platforms: ${{ steps.compute-platforms.outputs.PLATFORMS }}
           push: ${{ inputs.push }}
           pull: true
+          target: mambaforge-cuda
           build-args: |
             CUDA_VER=${{ matrix.CUDA_VER }}
             LINUX_VER=${{ matrix.LINUX_VER }}
             PYTHON_VER=${{ matrix.PYTHON_VER }}
-          tags: ${{ steps.compute-tags.outputs.TAGS }}
+          tags: ${{ steps.compute-tags.outputs.BASE_TAGS }}
+      - name: Build and push mambaforge-cuda-rapids
+        timeout-minutes: 10
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: ${{ steps.compute-platforms.outputs.PLATFORMS }}
+          push: ${{ inputs.push }}
+          pull: true
+          target: mambaforge-cuda-rapids
+          build-args: |
+            CUDA_VER=${{ matrix.CUDA_VER }}
+            LINUX_VER=${{ matrix.LINUX_VER }}
+            PYTHON_VER=${{ matrix.PYTHON_VER }}
+          tags: ${{ steps.compute-tags.outputs.RAPIDS_TAGS }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,10 +31,15 @@ RUN \
       && apt-get install -y --no-install-recommends \
         # needed by the ORC library used by pyarrow, because it provides /etc/localtime
         tzdata \
+        # needed by dask
+        libnuma1 libnuma-dev \
       && rm -rf "/var/lib/apt/lists/*"; \
       ;; \
     "centos"* | "rockylinux"*) \
       yum -y update \
+      && yum -y install --setopt=install_weak_deps=False \
+        # needed by dask
+        numactl-devel numactl-libs \
       && yum clean all; \
       ;; \
     *) \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG PYTHON_VER=3.9
 ENV PATH=/opt/conda/bin:$PATH
 ENV PYTHON_VERSION=${PYTHON_VER}
 
-COPY --from=condaforge/mambaforge:22.9.0-1 /opt/conda /opt/conda
+COPY --from=condaforge/mambaforge:22.9.0-2 /opt/conda /opt/conda
 RUN \
   # ensure conda environment is always activated
   ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 ARG CUDA_VER=11.4.0
 ARG LINUX_VER=ubuntu18.04
-FROM nvidia/cuda:${CUDA_VER}-base-${LINUX_VER}
+FROM nvidia/cuda:${CUDA_VER}-base-${LINUX_VER} AS mambaforge-cuda
 
-ARG LINUX_VER
 ARG PYTHON_VER=3.9
-ARG DEBIAN_FRONTEND=noninteractive
 ENV PATH=/opt/conda/bin:$PATH
 ENV PYTHON_VERSION=${PYTHON_VER}
 
@@ -19,12 +17,19 @@ RUN \
   mamba update --all -y; \
   find /opt/conda -follow -type f -name '*.a' -delete; \
   find /opt/conda -follow -type f -name '*.pyc' -delete; \
-  conda clean -afy; \
+  conda clean -afy;
+
+FROM mambaforge-cuda AS mambaforge-cuda-rapids
+ARG DEBIAN_FRONTEND=noninteractive
+ARG LINUX_VER
+
+RUN \
   case "${LINUX_VER}" in \
     "ubuntu"*) \
       apt-get update \
       && apt-get upgrade -y \
       && apt-get install -y --no-install-recommends \
+        # needed by the ORC library used by pyarrow, because it provides /etc/localtime
         tzdata \
       && rm -rf "/var/lib/apt/lists/*"; \
       ;; \


### PR DESCRIPTION
This PR splits the existing `rapidsai/mambaforge-cuda` image into the following images:

- `rapidsai/mambaforge-cuda`
- `rapidsai/mambaforge-cuda-rapids`

The second variant, `rapidsai/mambaforge-cuda-rapids`, can be used as a base image for RAPIDS CI images and end-user images while the first variant, `rapidsai/mambaforge-cuda`, can be used as a base image by the general public.

This distinction is helpful because there are some RAPIDS specific dependencies that need to be installed in both our CI and end-user images, but may not be helpful to others who want a clean `mambaforge-cuda` image.

Additionally, this PR installs `libnuma` which is needed by `dask` and updates the `mambaforge-cuda` image.