### PR TITLE
Don't build `arm` images for `rockylinux8` variants

### DIFF
--- a/ci/compute-arch.sh
+++ b/ci/compute-arch.sh
@@ -14,12 +14,12 @@ write_platforms() {
   echo "PLATFORMS=${PLATFORMS}" | tee --append "${GITHUB_OUTPUT:-/dev/null}"
 }
 
-# Ubuntu18.04 images don't officially support arm.
-# Even though Ubuntu18.04 images prior to CUDA 11.8.0 did
-# have arm variants, it was removed for 11.8.0.
+# Ubuntu18.04 and RockyLinux8 images don't officially support arm.
+# Even though Ubuntu18.04 and RockyLinux8 images prior to CUDA 11.8.0 did
+# have arm variants, they were removed for 11.8.0.
 if [[
   "${CUDA_VER}" == "11.8.0" &&
-  "${LINUX_VER}" == "ubuntu18.04"
+  ("${LINUX_VER}" == "ubuntu18.04" || "${LINUX_VER}" == "rockylinux8")
 ]]; then
   write_platforms "${PLATFORMS}"
   exit 0


### PR DESCRIPTION
Much like `ubuntu18.04`, it seems that the `rockylinux8` images also don't have `arm` variants available for CUDA `11.8`. This PR updates the `compute-arch.sh` script to ensure that those particular variants only build `amd64` images.

See https://hub.docker.com/r/nvidia/cuda/tags?page=1&name=11.8.0-base-rockylinux