### PR TITLE
Add a group for conda commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV PATH=/opt/conda/bin:$PATH
 ENV PYTHON_VERSION=${PYTHON_VER}
 
-COPY --from=condaforge/mambaforge:22.9.0-2 /opt/conda /opt/conda
+COPY --from=condaforge/mambaforge:22.9.0-2 --chmod=777 /opt/conda /opt/conda
 RUN \
   # ensure conda environment is always activated
   ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh; \
@@ -20,6 +20,7 @@ RUN \
   find /opt/conda -follow -type f -name '*.a' -delete; \
   find /opt/conda -follow -type f -name '*.pyc' -delete; \
   conda clean -afy; \
+  chmod 777 -R /opt/conda/; \
   case "${LINUX_VER}" in \
     "ubuntu"*) \
       apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,19 @@ ARG DEBIAN_FRONTEND=noninteractive
 ENV PATH=/opt/conda/bin:$PATH
 ENV PYTHON_VERSION=${PYTHON_VER}
 
-RUN useradd -rm -d /home/rapids -s /bin/bash -g root -u 1001 rapids
+# Create a conda group and assign it as root's primary group
+RUN groupadd conda; \
+  usermod -g conda root
 
-COPY --from=condaforge/mambaforge:22.9.0-2 --chown=rapids /opt/conda /opt/conda
+# Ownership & permissions based on https://docs.anaconda.com/anaconda/install/multi-user/#multi-user-anaconda-installation-on-linux
+COPY --from=condaforge/mambaforge:22.9.0-2 --chown=root:conda --chmod=770 /opt/conda /opt/conda
 
-USER rapids
+# Ensure new files are created with group write access & setgid. See https://unix.stackexchange.com/a/12845
+RUN chmod g+ws /opt/conda
 
 RUN \
+  # Ensure new files/dirs have group write/setgid permissions
+  umask g+ws; \
   # install expected Python version
   mamba install -y -n base python="${PYTHON_VERSION}"; \
   mamba update --all -y -n base; \
@@ -22,14 +28,16 @@ RUN \
   find /opt/conda -follow -type f -name '*.pyc' -delete; \
   conda clean -afy;
 
-USER root
+# Reassign root's primary group to root
+RUN usermod -g root root
 
 RUN \
   # ensure conda environment is always activated
   ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh; \
   echo ". /opt/conda/etc/profile.d/conda.sh; conda activate base" >> /etc/skel/.bashrc; \
-  echo ". /opt/conda/etc/profile.d/conda.sh; conda activate base" >> ~/.bashrc; \
-  case "${LINUX_VER}" in \
+  echo ". /opt/conda/etc/profile.d/conda.sh; conda activate base" >> ~/.bashrc;
+
+RUN case "${LINUX_VER}" in \
     "ubuntu"*) \
       apt-get update \
       && apt-get upgrade -y \

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A simple set of images that install [Mambaforge](https://github.com/conda-forge/miniforge) on top of the [nvidia/cuda](https://hub.docker.com/r/nvidia/cuda) images.
 
-These images are intended to be used as a base image for other RAPIDS images.
+These images are intended to be used as a base image for other RAPIDS images. Downstream images can create a user with the `conda` user group which has write access to the base conda environment in the image.
 
 ## `latest` tag
 


### PR DESCRIPTION
In order for downstream images to install conda packages as a non-root user, we should install the conda environment & packages writable by a group. So this image will now create a `conda` group and ensure permissions are set for group access.

Downstream images can reuse this `conda` group.

Required for https://github.com/rapidsai/docker/issues/539

I tested locally like so:

`docker buildx build -f Dockerfile -t rapidsai/mambaforge-cuda-777:cuda11.8.0-base-ubuntu22.04-py3.10 --build-arg CUDA_VER=11.8.0 --build-arg LINUX_VER=ubuntu22.04 --build-arg PYTHON_VER=3.10 .`

Then build this Dockerfile:
```Dockerfile
FROM rapidsai/mambaforge-cuda-777:cuda11.8.0-base-ubuntu22.04-py3.10

RUN useradd -rm -d /home/rapids -s /bin/bash -g conda -u 1001 rapids

USER rapids

RUN mamba install -n base -y curl
```