### PR TITLE
[skip ci] Enable `copy_prs` plugin

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -1,0 +1,4 @@
+# This file controls which features from the `ops-bot` repository below are enabled.
+# - https://github.com/rapidsai/ops-bot
+
+copy_prs: true


### PR DESCRIPTION
To be able to use self hosted runners on PRs, we need to enable the `copy_prs` plugin from the `ops-bot`