### PR TITLE
Make `jq` functions fully generic

### DIFF
--- a/ci/compute-mx.jq
+++ b/ci/compute-mx.jq
@@ -19,14 +19,18 @@ def matches($entry; $exclude):
 def filter_excludes($entry; $excludes):
   select(any($excludes[]; matches($entry; .)) | not);
 
+def lists2dict($keys; $values):
+  reduce range($keys | length) as $ind ({}; . + {($keys[$ind]): $values[$ind]});
+
 def compute_mx($input):
   ($input.exclude // []) as $excludes |
   $input | del(.exclude) |
+  keys_unsorted as $mx_keys |
   to_entries |
   map(.value) |
   [
     combinations |
-    {CUDA_VER: .[0], PYTHON_VER: .[1], LINUX_VER: .[2]} |
+    lists2dict($mx_keys; .) |
     filter_excludes(.; $excludes) |
     compute_arch(.)
   ] |


### PR DESCRIPTION
This PR updates the `jq` functions to make them fully generic.

Previously the `jq` functions included the keys from `axis.yaml` which resulted in some duplication that would be tedious to maintain.

Now the `axis.yaml` file can be updated without having to also update `compute-mx.jq`.

Since these `jq` functions are now fully generic, they can also be consolidated into a composite action to facilitate reusability.