### PR TITLE
Add workflow_dispatch & schedule to merge worfklow

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,6 +1,9 @@
 name: publish
 
 on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 0 * * *'
   push:
     branches:
       - "main"


### PR DESCRIPTION
Adds two new triggers to the `merge` workflow:
1. `workflow_dispatch` for manual builds
2. `schedule` to rebuild nightly
