### PR TITLE
Trigger CI img rebuilds

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,3 +18,12 @@ jobs:
     with:
       build_type: branch
     secrets: inherit
+  trigger-pipeline:
+    runs-on: ubuntu-latest
+    needs: build-images
+    steps:
+      - name: Trigger Pipeline
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
+        run: |
+          gh workflow run build-and-publish-images.yml -R github.com/rapidsai/ci-imgs -r main --json '{"build_type":"branch"}'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,8 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-images
     steps:
-      - name: Trigger Pipeline
+      - name: Trigger CI Images
         env:
           GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
         run: |
-          gh workflow run build-and-publish-images.yml -R github.com/rapidsai/ci-imgs -r main --json '{"build_type":"branch"}'
+          gh workflow run push.yml \
+          --repo github.com/rapidsai/ci-imgs \
+          --ref main


### PR DESCRIPTION
Configures the publish workflow to trigger `build-and-publish-images` workflow of `ci-imgs` due to being an upstream dependency.