### PR TITLE
Switch to miniforge

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,6 +28,6 @@ jobs:
         run: |
           gh workflow run push.yml \
           --field upstream_job="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
-          --field upstream_repository=mambaforge-cuda \
+          --field upstream_repository=miniforge-cuda \
           --repo rapidsai/ci-imgs \
           --ref main

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN groupadd conda; \
   usermod -g conda root
 
 # Ownership & permissions based on https://docs.anaconda.com/anaconda/install/multi-user/#multi-user-anaconda-installation-on-linux
-COPY --from=condaforge/mambaforge:23.3.1-0 --chown=root:conda --chmod=770 /opt/conda /opt/conda
+COPY --from=condaforge/miniforge3:23.3.1-1 --chown=root:conda --chmod=770 /opt/conda /opt/conda
 
 # Ensure new files are created with group write access & setgid. See https://unix.stackexchange.com/a/12845
 RUN chmod g+ws /opt/conda

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# mambaforge-cuda
+# miniforge-cuda
 
-A simple set of images that install [Mambaforge](https://github.com/conda-forge/miniforge) on top of the [nvidia/cuda](https://hub.docker.com/r/nvidia/cuda) images.
+A simple set of images that install [Miniforge](https://github.com/conda-forge/miniforge) on top of the [nvidia/cuda](https://hub.docker.com/r/nvidia/cuda) images.
 
 These images are intended to be used as a base image for other RAPIDS images. Downstream images can create a user with the `conda` user group which has write access to the base conda environment in the image.
 

--- a/matrix.yaml
+++ b/matrix.yaml
@@ -14,7 +14,7 @@ LINUX_VER:
   - "centos7"
   - "rockylinux8"
 IMAGE_REPO:
-  - "mambaforge-cuda"
+  - "miniforge-cuda"
 exclude:
   - LINUX_VER: "ubuntu22.04"
     CUDA_VER: "11.2.2"

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "packageRules": [
     {
       "matchDatasources": ["docker"],
-      "matchPackageNames": ["condaforge/mambaforge"],
+      "matchPackageNames": ["condaforge/miniforge3"],
       "versioning": "loose"
     }
   ]


### PR DESCRIPTION
Following conda-forge's [recommendation](https://github.com/conda-forge/miniforge/pull/488/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R58) to switch to miniforge. This PR makes the switch.

References to `rapidsai/mambaforge-cuda` across our codebase will be replaced with `rapidsai/miniforge-cuda` once this PR is merged and the new images get deployed.