### PR TITLE
Fix triggered workflow error

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
         run: |
-          gh workflow run push.yml \
+          gh workflow run push.yaml \
           --field upstream_job="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
           --field upstream_repository=mambaforge-cuda \
           --repo rapidsai/ci-imgs \


### PR DESCRIPTION
The workflow file in the trigger downstream repository was renamed [here](https://github.com/rapidsai/ci-imgs/commit/ca7457b543b7921c912913a6469f3b2c65029eab) and this was causing a failure as shown [here](https://github.com/rapidsai/mambaforge-cuda/actions/runs/6607110220/job/17944207727).

This PR fixes it.